### PR TITLE
Update DeepCTR requirement in `setup.py` to allow 0.8.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 REQUIRED_PACKAGES = [
-    'h5py', 'requests', "deepctr==0.8.2"
+    'h5py', 'requests', "deepctr>=0.8.2"
 ]
 
 setuptools.setup(


### PR DESCRIPTION
The tests pass using DeepCTR 0.8.5, so unless there's a known incompatibility, it seems safe to update the version requirement to allow that combination of the two libraries.